### PR TITLE
Removing end time options. Moved into TEC settings.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, calendar
 Requires at least: 4.9
 Tested up to: 6.3.1
 Requires PHP: 5.6
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: GPL version 3 or any later version
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -283,14 +283,6 @@ if ( ! class_exists( Settings::class ) ) {
 		 * @return array[]
 		 */
 		public function get_settings_fields() {
-			$remove_event_end_time_in_views = [
-				'recent' => esc_html__( 'Recent past events list', 'tec-labs-tec-tweaks' ),
-				'single' => esc_html__( 'Single event page', 'tec-labs-tec-tweaks' ),
-				'day'    => esc_html__( 'Day view', 'tec-labs-tec-tweaks' ),
-				'list'   => esc_html__( 'List view', 'tec-labs-tec-tweaks' ),
-				'month'  => esc_html__( 'Month view tooltip', 'tec-labs-tec-tweaks' ),
-			];
-
 			$remove_links_from_events_views = [
 				'tribe-events-calendar-day__event-title-link'            => esc_html__( 'Day view', 'tec-labs-tec-tweaks' ),
 				'tribe-events-calendar-list__event-title-link'           => esc_html__( 'List view', 'tec-labs-tec-tweaks' ),
@@ -299,8 +291,6 @@ if ( ! class_exists( Settings::class ) ) {
 
 			// IF ECP is active, show more options.
 			if ( class_exists( 'Tribe__Events__Pro__Main' ) ) {
-				$remove_event_end_time_in_views['week'] = esc_html__( 'Week view tooltip', 'tec-labs-tec-tweaks' );
-
 				$remove_links_from_events_views['tribe-events-pro-map__event-card-button']  = esc_html__( 'Map view', 'tec-labs-tec-tweaks' );
 				$remove_links_from_events_views['tribe-events-pro-photo__event-title-link'] = esc_html__( 'Photo view', 'tec-labs-tec-tweaks' );
 				$remove_links_from_events_views['tribe-events-pro-week-grid__event-link']   = esc_html__( 'Week view', 'tec-labs-tec-tweaks' );
@@ -323,20 +313,6 @@ if ( ! class_exists( Settings::class ) ) {
 						'tec-labs-tec-tweaks'
 					),
 					'validation_type' => 'boolean',
-				],
-				'remove_event_end_time'             => [
-					'type'            => 'checkbox_list',
-					'label'           => esc_html__( 'Remove event end time', 'tec-labs-tec-tweaks' ),
-					'tooltip'         => esc_html__(
-							'When this box is checked the end time will no longer display for events that end on the same day when viewing the List and Day views, the recent past events list, the tooltip in Month and Week (Pro) views, as well as on the event page itself.',
-							'tec-labs-tec-tweaks'
-						) . '<br><i>' . esc_html__(
-							'Source:',
-							'tec-labs-tec-tweaks'
-						) . ' <a href="https://theeventscalendar.com/knowledgebase/k/remove-the-event-end-time-in-views/" target="_blank">Remove the Event End Time in Views</a></i>',
-					'options'         => $remove_event_end_time_in_views,
-					'validation_type' => 'options_multi',
-					'can_be_empty'    => true,
 				],
 				'hide_tooltip'                      => [
 					'type'            => 'checkbox_bool',

--- a/tribe-ext-tec-tweaks.php
+++ b/tribe-ext-tec-tweaks.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/the-events-calendar-tweaks/
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-tec-tweaks/
  * Description:       A combination of snippets and tweaks for The Events Calendar
- * Version:           1.1.1
+ * Version:           1.1.2
  * Extension Class:   Tribe\Extensions\Tec_Tweaks\Main
  * Author:            The Events Calendar
  * Author URI:        http://evnt.is/1971
@@ -129,7 +129,6 @@ if (
 			$this->get_settings();
 
 			$this->disable_latest_past_events();
-			$this->hide_event_end_time();
 			$this->hide_tooltip();
 			$this->hide_past_events_in_month_view();
 			$this->hide_event_time_in_month_view();
@@ -289,39 +288,6 @@ if (
 			if ( $days_to_show ) {
 				add_filter( 'tribe_events_views_v2_show_latest_past_events_view', '__return_false' );
 			}
-		}
-
-		/**
-		 * Hides the event end time on several views.
-		 */
-		public function hide_event_end_time() {
-			$views = (array) $this->settings->get_option( 'remove_event_end_time', [] );
-
-			if ( empty ( $views ) ) {
-				return;
-			}
-
-			// If there are any views checked, then run the filter.
-			add_filter(
-				'tribe_events_event_schedule_details_formatting',
-				function ( $settings ) {
-					$views = (array) $this->settings->get_option( 'remove_event_end_time', [] );
-
-					foreach ( $views as $view ) {
-						if (
-							tribe_is_view( $view )
-							|| $view === tribe_context()->get( 'view', false )
-						) {
-							$settings['show_end_time'] = false;
-
-							// If we found the view we are on, no need to go any further.
-							break;
-						}
-					}
-
-					return $settings;
-				}
-			);
 		}
 
 		/**


### PR DESCRIPTION
[[TEC-4371](https://stellarwp.atlassian.net/browse/TEC-4371)]

Removing end time options. These have been moved up to the TEC repo in the Display settings.

![image](https://github.com/mt-support/tribe-ext-tec-tweaks/assets/2826045/6a9e2584-ce11-46a6-a46c-06bf774ed7eb)
